### PR TITLE
Remove SSO buttons and fix the scrolling

### DIFF
--- a/web/app/create/post/page.tsx
+++ b/web/app/create/post/page.tsx
@@ -36,7 +36,7 @@ function CreatePostForm({ user }: { user: { username: string } }) {
   };
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
+    <div className="max-w-4xl px-4 py-8 flex-1 w-full">
       <PostForm
         onSubmit={handleFormSubmit}
         submitButtonText="Publish"

--- a/web/app/feed/popular/page.tsx
+++ b/web/app/feed/popular/page.tsx
@@ -8,7 +8,7 @@ export default function PopularPage() {
   const { user, isLoading } = useAuth();
 
   if (isLoading) {
-    return <LoadingSpinner text="Loading..." fullPage center />;
+    return <LoadingSpinner text="Loading..." center />;
   }
 
   return <FeedLayout feedType="popular" user={user || undefined} />;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -15,10 +15,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased min-h-screen">
+      <body className="antialiased min-h-screen flex flex-col">
         <AuthProvider>
           <Navbar />
-          <main className="px-2 sm:px-4 lg:px-8 py-6">{children}</main>
+          <main className="px-2 sm:px-4 lg:px-8 py-6 flex flex-1 flex-col items-center">
+            {children}
+          </main>
         </AuthProvider>
       </body>
     </html>

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -33,7 +33,7 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white relative">
+    <div className="flex-1 flex items-center justify-center relative">
       <div className="max-w-md w-full space-y-8 relative z-10">
         <div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-stone-900">
@@ -77,7 +77,8 @@ export default function LoginPage() {
             </button>
           </form>
 
-          <div className="flex justify-end">
+          {/* sso is not yet implemented */}
+          {/* <div className="flex justify-end">
             <button className="text-sm text-blue-600 hover:text-blue-500 underline transition-colors">
               Forgot your password?
             </button>
@@ -123,7 +124,7 @@ export default function LoginPage() {
               </svg>
               Sign in with GitHub
             </button>
-          </div>
+          </div> */}
 
           <div className="text-center mt-6">
             <p className="text-sm text-stone-600">

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -19,5 +19,5 @@ export default function Home() {
     }
   }, [isAuthenticated, isLoading, router]);
 
-  return <LoadingSpinner fullPage center />;
+  return <LoadingSpinner center />;
 }

--- a/web/app/post/[id]/edit/page.tsx
+++ b/web/app/post/[id]/edit/page.tsx
@@ -109,7 +109,7 @@ function EditPostContent({
 
   if (error && !post) {
     return (
-      <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="max-w-4xl mx-auto px-4 py-8 flex-1 w-full">
         <ErrorMessage
           title="Failed to Load Post"
           message={error}
@@ -124,7 +124,7 @@ function EditPostContent({
   }
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8">
+    <div className="max-w-4xl mx-auto px-4 py-8 flex-1 w-full">
       <PostForm
         initialTitle={post.title}
         initialContent={post.content}

--- a/web/app/profile/[username]/page.tsx
+++ b/web/app/profile/[username]/page.tsx
@@ -17,51 +17,49 @@ export default function UserProfilePage() {
   const { todayWordCount } = useTodayWordCount();
 
   if (loading) {
-    return <LoadingSpinner text="Loading profile..." fullPage center />;
+    return <LoadingSpinner text="Loading profile..." center />;
   }
 
   if (error || !user) {
     return (
-      <div className="min-h-screen">
-        <div className="w-full max-w-[1476px] mx-auto flex justify-center items-center px-4 sm:px-6 lg:px-8 py-6">
-          <ErrorMessage
-            title={error ? "Failed to load profile" : "User not found"}
-            message={error || "The user could not be found."}
-            onRetry={refetch}
-            showRetryButton={!!error}
-          />
-        </div>
+      <div className="w-full max-w-[1476px] mx-auto flex justify-center items-center px-4 sm:px-6 lg:px-8 py-6">
+        <ErrorMessage
+          title={error ? "Failed to load profile" : "User not found"}
+          message={error || "The user could not be found."}
+          onRetry={refetch}
+          showRetryButton={!!error}
+        />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen">
-      <div className="w-full max-w-[1476px] mx-auto flex justify-center items-start gap-4 lg:gap-8 xl:gap-16 px-4 sm:px-6 lg:px-8 py-6">
-        <div className="hidden xl:flex w-60 flex-col gap-8 flex-shrink-0 sticky top-16">
-          {currentUser && currentUser.id !== user.id && <UserProfile user={currentUser} />}
-          <WritePostCTA todayWordCount={todayWordCount} />
+    <div className="w-full max-w-[1476px] mx-auto flex justify-center items-start gap-4 lg:gap-8 xl:gap-16 px-4 sm:px-6 lg:px-8 py-6">
+      <div className="hidden xl:flex w-60 flex-col gap-8 flex-shrink-0 sticky top-16">
+        {currentUser && currentUser.id !== user.id && (
+          <UserProfile user={currentUser} />
+        )}
+        <WritePostCTA todayWordCount={todayWordCount} />
+      </div>
+
+      <div className="flex flex-col gap-8 w-full max-w-[600px] min-w-0">
+        <div className="bg-white shadow rounded-lg">
+          <UserProfile user={user} size="lg" />
         </div>
 
-        <div className="flex flex-col gap-8 w-full max-w-[600px] min-w-0">
-          <div className="bg-white shadow rounded-lg">
-            <UserProfile user={user} size="lg" />
-          </div>
-
-          <div className="flex flex-col gap-6 md:gap-8">
-            {posts.map((post) => (
-              <PostCard
-                key={post.id}
-                post={post}
-                onPostUpdate={handlePostUpdate}
-              />
-            ))}
-          </div>
+        <div className="flex flex-col gap-6 md:gap-8">
+          {posts.map((post) => (
+            <PostCard
+              key={post.id}
+              post={post}
+              onPostUpdate={handlePostUpdate}
+            />
+          ))}
         </div>
+      </div>
 
-        <div className="hidden lg:flex w-60 flex-col gap-8 flex-shrink-0 sticky top-16">
-          <WhoToFollow />
-        </div>
+      <div className="hidden lg:flex w-60 flex-col gap-8 flex-shrink-0 sticky top-16">
+        <WhoToFollow />
       </div>
     </div>
   );

--- a/web/app/profile/edit/page.tsx
+++ b/web/app/profile/edit/page.tsx
@@ -26,7 +26,7 @@ function EditProfileContent({ user }: { user: User }) {
   };
 
   return (
-    <div className="min-h-screen">
+    <div className="flex-1 w-full">
       <div className="w-full max-w-[1476px] mx-auto flex justify-center items-start px-4 sm:px-6 lg:px-8 py-6">
         <div className="w-full max-w-[600px]">
           {/* Header */}

--- a/web/app/signup/page.tsx
+++ b/web/app/signup/page.tsx
@@ -41,7 +41,7 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white relative">
+    <div className="flex-1 flex items-center justify-center relative">
       <div className="max-w-md w-full space-y-8 relative z-10">
         <div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-stone-900">
@@ -102,7 +102,8 @@ export default function SignupPage() {
             </button>
           </form>
 
-          <div className="relative">
+          {/* sso is not yet implemented */}
+          {/* <div className="relative">
             <div className="absolute inset-0 flex items-center">
               <div className="w-full border-t border-stone-300" />
             </div>
@@ -142,7 +143,7 @@ export default function SignupPage() {
               </svg>
               Sign up with GitHub
             </button>
-          </div>
+          </div> */}
 
           <div className="text-center mt-6">
             <p className="text-sm text-stone-600">

--- a/web/components/AuthenticatedRoute.tsx
+++ b/web/components/AuthenticatedRoute.tsx
@@ -27,7 +27,7 @@ export function AuthenticatedRoute({
   }, [isAuthenticated, isLoading, router, redirectTo]);
 
   if (isLoading) {
-    return <LoadingSpinner text={loadingText} fullPage center />;
+    return <LoadingSpinner text={loadingText} center />;
   }
 
   if (!isAuthenticated || !user) {

--- a/web/components/FollowLayout.tsx
+++ b/web/components/FollowLayout.tsx
@@ -25,12 +25,12 @@ export default function FollowLayout({
   type,
 }: FollowLayoutProps) {
   if (loading) {
-    return <LoadingSpinner text={`Loading ${type}...`} fullPage center />;
+    return <LoadingSpinner text={`Loading ${type}...`} center />;
   }
 
   if (error || !user) {
     return (
-      <div className="min-h-screen">
+      <div className="flex-1 w-full">
         <div className="w-full max-w-[1476px] mx-auto flex justify-center items-center px-4 sm:px-6 lg:px-8 py-6">
           <ErrorMessage
             title={error ? `Failed to load ${type}` : "User not found"}
@@ -50,7 +50,7 @@ export default function FollowLayout({
     : `${count} following`;
 
   return (
-    <div className="min-h-screen">
+    <div className="flex-1 w-full">
       <div className="w-full max-w-[1476px] mx-auto flex justify-center items-start px-4 sm:px-6 lg:px-8 py-6">
         <div className="w-full max-w-[600px]">
           <div className="mb-6">

--- a/web/components/LoadingSpinner.tsx
+++ b/web/components/LoadingSpinner.tsx
@@ -2,7 +2,6 @@ interface LoadingSpinnerProps {
   size?: "sm" | "md" | "lg";
   text?: string;
   className?: string;
-  fullPage?: boolean;
   center?: boolean;
 }
 
@@ -10,7 +9,6 @@ export default function LoadingSpinner({
   size = "md",
   text = "Loading...",
   className = "",
-  fullPage = false,
   center = false,
 }: LoadingSpinnerProps) {
   const sizeClasses = {
@@ -21,7 +19,6 @@ export default function LoadingSpinner({
 
   const containerClasses = [
     "flex flex-col items-center justify-center",
-    fullPage && "min-h-screen",
     center && "w-full max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6",
     className,
   ]


### PR DESCRIPTION
Commented out SSO buttons and Forgotten Password link. Fix the login, sign up, follow count pages to prevent them scrolling when it isn't needed (login fields are still centred). Removed the fullpage prop from the LoadingSpinner because it did nothing. Closes #6 